### PR TITLE
Fixed whole cube rotation 

### DIFF
--- a/cube/script.js
+++ b/cube/script.js
@@ -382,7 +382,6 @@ class Cube {
 
         const m = new Move(axisIndex, rotationAngle);
         this.animateMove(m);
-        this.addMove(m);
     }
 
     /**
@@ -584,4 +583,3 @@ function endTouch(event) {
         currentTouch = undefined;
     }
 }
-


### PR DESCRIPTION
Fixes an issue causing the whole cube to rotate incorrectly due to redundant `addMove ` call. The redundant code has been removed, resolving the problem.